### PR TITLE
Implement faster backwards reachability computation in automata

### DIFF
--- a/bin/experiments-capheus.sh
+++ b/bin/experiments-capheus.sh
@@ -4,8 +4,8 @@ CURRENT_VERSION=$(git rev-parse --short HEAD)
 RAM_ALLOC=4g
 NR_THREADS=10
 
+git reset --hard
 git pull
-git checkout master
 sbt assembly
 
 parallel -j$NR_THREADS --header : \

--- a/bin/experiments-capheus.sh
+++ b/bin/experiments-capheus.sh
@@ -12,4 +12,4 @@ parallel -j$NR_THREADS --header : \
   --eta --results $CURRENT_VERSION.capheus java -jar -Xmx${RAM_ALLOC} $JARFILE \
   solve-satisfy --timeout 60000 \
   --backend {backend} {chunk} \
-  ::: backend nuxmv lazy ::: chunk chunks/chunk-*
+  ::: backend baseline nuxmv lazy ::: chunk chunks/chunk-*

--- a/src/main/scala/uuverifiers/catra/InputFileParser.scala
+++ b/src/main/scala/uuverifiers/catra/InputFileParser.scala
@@ -20,7 +20,7 @@ sealed case class Constant(value: Int) extends Term {
   override def counters(): Set[Counter] = Set.empty
 }
 
-sealed case class Counter(name: String) extends Term {
+sealed case class Counter(name: String) extends Term with Ordered[Counter] {
   def incrementBy(i: Int): Map[Counter, Int] = Map(this -> i)
 
   def toConstant(p: SimpleAPI): ConstantTerm = p.createConstantRaw(name)
@@ -31,6 +31,8 @@ sealed case class Counter(name: String) extends Term {
     CounterWithCoefficient(-1, this)
 
   override def counters(): Set[Counter] = Set(this)
+
+  override def compare(that: Counter): Int = this.name compare that.name
 }
 
 sealed abstract class Atom extends Formula {

--- a/src/main/scala/uuverifiers/common/AutomatonBuilder.scala
+++ b/src/main/scala/uuverifiers/common/AutomatonBuilder.scala
@@ -8,8 +8,7 @@ class AutomatonBuilder extends Tracing {
   private var _outgoingTransitions = Map[State, SortedSet[Transition]]()
   private var _initial: Option[State] = None
   private var _accepting = Set[State]()
-  private var forwardReachable = Set[State]()
-  private var backwardReachable = Set[State]()
+  private var forwardReachable = mutable.HashSet[State]()
   private var name: Option[String] = None
 
   /**
@@ -17,82 +16,13 @@ class AutomatonBuilder extends Tracing {
    *
    * @param s The state to set reachable
    */
-  private def setFwdReachable(s: State) =
-    trace(s"setting forward reachable $s") {
-      var todo = List(s)
-
-      def markReachable(s: State): Unit = {
-        forwardReachable += s
-      }
-      def enqueue(s: State): Unit = trace(s"adding $s to queue") {
-        todo = s :: todo
-      }
-
-      markReachable(s)
-
-      while (todo.nonEmpty) {
-        val current = todo.head
-        todo = todo.tail
-
-        for (t <- _outgoingTransitions.getOrElse(current, Seq())) {
-          val targetSeenBefore = forwardReachable contains t.to()
-          if (!targetSeenBefore) {
-            enqueue(t.to())
-            markReachable(t.to())
-          }
-        }
-      }
-      forwardReachable
-    }
-
-  /**
-   * Start a backwards reachability search here, populating
-   * backwardsReachable.
-   *
-   * @param startingState
-   */
-  private def startBwdReachability(startingState: State) =
-    trace(s"start backwardsReachable $startingState") {
-      val reachedFrom = new mutable.HashMap[State, ArrayBuffer[State]]
-      var todo = List[State](startingState)
-
-      def enqueue(s: State): Unit = trace(s"adding $s to queue") {
-        todo = s :: todo
-      }
-
-      def dequeue() = {
-        val next = todo.head
-        todo = todo.tail
-        next
-      }
-
-      def markReachable(s: State): Unit =
-        trace(s"$s is backwards reachable") {
-          backwardReachable += s
-        }
-
-      _outgoingTransitions.values.flatten
-        .foreach(
-          t => reachedFrom.getOrElseUpdate(t.to(), new ArrayBuffer) += t.from()
-        )
-
-      markReachable(startingState)
-
-      while (todo.nonEmpty) {
-        val next = dequeue()
-
-        for (sources <- reachedFrom get next)
-          for (source <- sources) {
-            val sourceSeenBefore = backwardReachable contains source
-            if (!sourceSeenBefore) {
-              markReachable(source)
-              enqueue(source)
-            }
-          }
-      }
-
-      backwardReachable
-    }
+  private def setFwdReachable(s: State): mutable.HashSet[State] =
+    ClosureComputation.computeClosure(
+      startingFrom = Set(s),
+      seen = forwardReachable,
+      findMoreFrom =
+        (s: State) => _outgoingTransitions.getOrElse(s, Seq()).map(_.to())
+    )
 
   def nameIs(n: String): AutomatonBuilder = {
     this.name = Some(n)
@@ -125,7 +55,7 @@ class AutomatonBuilder extends Tracing {
 
   def setInitial(newInitialState: State): AutomatonBuilder = {
     assertHasState(newInitialState)
-    forwardReachable = Set() // All states are now unreachable...
+    forwardReachable = mutable.HashSet() // All states are now unreachable...
     _initial = Some(newInitialState)
     setFwdReachable(newInitialState) //...until we recompute.
     this
@@ -134,20 +64,17 @@ class AutomatonBuilder extends Tracing {
   def setAccepting(acceptingStates: State*): AutomatonBuilder = {
     assert(acceptingStates forall (_autStates(_)))
     _accepting ++= acceptingStates
-    acceptingStates.foreach(s => startBwdReachability(s))
     this
   }
 
   def setNotAccepting(notAcceptingStates: State*): AutomatonBuilder = {
     assert(notAcceptingStates forall (_autStates(_)))
-    backwardReachable = Set()
     _accepting --= notAcceptingStates
-    _accepting.foreach(s => startBwdReachability(s))
     this
   }
 
   def addTransition(t: Transition): AutomatonBuilder = {
-    trace(s"add transition $t on $name")()
+    trace(s"add transition $t on $name")(_outgoingTransitions.size)
     assert((_autStates contains t.from()) && (_autStates contains t.to()))
 
     _outgoingTransitions = _outgoingTransitions.updatedWith(t.from()) {
@@ -159,10 +86,6 @@ class AutomatonBuilder extends Tracing {
       setFwdReachable(t.to())
     }
 
-    if (backwardReachable contains t.to()) {
-      startBwdReachability(t.from())
-    }
-
     this
   }
 
@@ -171,6 +94,16 @@ class AutomatonBuilder extends Tracing {
 
     if (!_accepting.exists(forwardReachable contains _))
       return trace("AutomatonBuilder::getAutomaton")(REJECT_ALL)
+
+    val backwardReachable = {
+      val transitionsReversed =
+        _outgoingTransitions.values.flatten.groupMap(_.to())(_.from())
+
+      ClosureComputation.computeClosure(
+        startingFrom = _accepting,
+        findMoreFrom = (s: State) => transitionsReversed.getOrElse(s, Seq())
+      )
+    }
 
     // Ignore transitions into and from dead states (unreachable, or where no
     // path leads on to an accepting state)

--- a/src/main/scala/uuverifiers/common/ClosureComputation.scala
+++ b/src/main/scala/uuverifiers/common/ClosureComputation.scala
@@ -1,0 +1,21 @@
+package uuverifiers.common
+
+import scala.collection.mutable
+
+object ClosureComputation {
+  def computeClosure[T](
+      startingFrom: Set[T],
+      findMoreFrom: T => Iterable[T],
+      seen: mutable.HashSet[T] = mutable.HashSet[T]()
+  ): mutable.HashSet[T] = {
+    val todo: mutable.Queue[T] =
+      new mutable.Queue(startingFrom.size).addAll(startingFrom)
+
+    while (todo.nonEmpty) {
+      val current = todo.dequeue()
+      seen add current
+      todo enqueueAll findMoreFrom(current).filterNot(seen.contains).toSet
+    }
+    seen
+  }
+}

--- a/src/main/scala/uuverifiers/common/Tracing.scala
+++ b/src/main/scala/uuverifiers/common/Tracing.scala
@@ -2,7 +2,7 @@ package uuverifiers.common
 import scala.annotation.elidable
 import scala.annotation.elidable.FINE
 import collection.mutable.HashMap
-import scala.collection.{AbstractMap, AbstractSet, mutable}
+import scala.collection.{AbstractMap, AbstractSet}
 
 object Statistics {
   private val dynTraceEnable = sys.env
@@ -51,17 +51,20 @@ trait Tracing {
   protected def logException(e: Throwable) =
     e.printStackTrace()
 
-  protected def trace[T, V <: Ordered[V], K <: Ordered[K]](
+  protected def trace[T, V <: Ordered[V], HV <: Ordered[HV], K <: Ordered[K]](
       message: String = ""
-  )(something: T): T = {
-    val determinised = something match {
-      case m: AbstractSet[V]    => m.toIndexedSeq.sorted
-      case m: AbstractMap[K, V] => m.toIndexedSeq.sorted
-      case _                    => something
+  )(something: T): T =
+    if (dynTraceEnable) {
+      val determinised = something match {
+        case m: AbstractSet[HV]   => m.toIndexedSeq.sorted
+        case m: AbstractMap[K, V] => m.toIndexedSeq.sorted
+        case _                    => something
+      }
+
+      logInfo(s"trace::${context}::$message($determinised)")
+
+      something
+    } else {
+      something
     }
-
-    logInfo(s"trace::${context}::$message($determinised)")
-
-    something
-  }
 }


### PR DESCRIPTION
Experiments confirm this branch is slightly better than previous mainline.

The number of observed unsound instances increases from 15 to 18, but I don't think this is due to a bug in the automata implementation, but rather a side effect of other operations now being faster and thus hitting the bug more often. Or just random chance.

Closes: #42 