### PR TITLE
Parse bug: negations for inequality constraints are ignored

### DIFF
--- a/src/main/scala/uuverifiers/catra/InputFileParser.scala
+++ b/src/main/scala/uuverifiers/catra/InputFileParser.scala
@@ -56,15 +56,15 @@ sealed case class Inequality(
 
     inequality match {
       case LessThan if isPositive            => left < right
-      case LessThan if !isPositive           => left > right
+      case LessThan if !isPositive           => left >= right
       case GreaterThan if isPositive         => left > right
-      case GreaterThan if !isPositive        => left < right
+      case GreaterThan if !isPositive        => left <= right
       case Equals if isPositive              => left === right
       case Equals if !isPositive             => left =/= right
       case GreaterThanOrEqual if isPositive  => left >= right
-      case GreaterThanOrEqual if !isPositive => left <= right
+      case GreaterThanOrEqual if !isPositive => left < right
       case LessThanOrEqual if isPositive     => left <= right
-      case LessThanOrEqual if !isPositive    => left >= right
+      case LessThanOrEqual if !isPositive    => left > right
       case NotEquals if isPositive           => left =/= right
       case NotEquals if !isPositive          => left === right
     }

--- a/src/main/scala/uuverifiers/catra/InputFileParser.scala
+++ b/src/main/scala/uuverifiers/catra/InputFileParser.scala
@@ -55,12 +55,18 @@ sealed case class Inequality(
     val right = rhs.toPrincess(counterConstants)
 
     inequality match {
-      case LessThan           => left < right
-      case GreaterThan        => left > right
-      case Equals             => left === right
-      case GreaterThanOrEqual => left >= right
-      case LessThanOrEqual    => left <= right
-      case NotEquals          => left =/= right
+      case LessThan if isPositive            => left < right
+      case LessThan if !isPositive           => left > right
+      case GreaterThan if isPositive         => left > right
+      case GreaterThan if !isPositive        => left < right
+      case Equals if isPositive              => left === right
+      case Equals if !isPositive             => left =/= right
+      case GreaterThanOrEqual if isPositive  => left >= right
+      case GreaterThanOrEqual if !isPositive => left <= right
+      case LessThanOrEqual if isPositive     => left <= right
+      case LessThanOrEqual if !isPositive    => left >= right
+      case NotEquals if isPositive           => left =/= right
+      case NotEquals if !isPositive          => left === right
     }
   }
 

--- a/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
+++ b/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
@@ -28,8 +28,10 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
 
   import instance._
   val baseCommand = Array("nuxmv", "-int")
-  val Unreachable = """^-- invariant block .* is true$""".r
-  val Reachable = """^-- invariant block .* is false$""".r
+  // val Unreachable = """^-- invariant block .* is true$""".r
+  // val Reachable = """^-- invariant block .* is false$""".r
+  val Unreachable = """^-- invariant .* is true$""".r
+  val Reachable = """^-- invariant .* is false$""".r
   val CounterValue = """^ {4}counter_(\d+) = (\d+)$""".r
 
   val nuxmvCmd = arguments.timeout_ms match {
@@ -41,8 +43,9 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
 
   trace("nuxmv command line")(nuxmvCmd.mkString(" "))
 
-  val outFile =
-    File.createTempFile("parikh-", ".smv")
+  val outFile = new File("parikh.smv")
+  // val outFile =
+  //   File.createTempFile("parikh-", ".smv")
 
   val blockNum =
     automataProducts.size
@@ -209,10 +212,16 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
         )
       }
 
-    println("  " + or((autTransitions ++ blockTransitions): _*))
+    println("  " + or((autTransitions): _*))
+    // println("  " + or((autTransitions ++ blockTransitions): _*))
 
     println("INVARSPEC")
-    println("  " + blockVar + " != " + blockNum + ";")
+    println("! (" + and(
+              (for (c <- constraints)
+                yield SimpleAPI.pp(c.toPrincess(counterSubst))): _*
+            ) + ");")
+    // println("  " + blockVar + " != " + blockNum + ";")
+
   }
 
   val result: Try[SatisfactionResult] =
@@ -222,8 +231,6 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
         printNUXMVModule()
       }
       out.close()
-
-      printNUXMVModule()
 
       val process = Runtime.getRuntime.exec(nuxmvCmd)
       val stdin = process.getOutputStream
@@ -302,6 +309,6 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
         result
       }
     } finally {
-      outFile.delete
+      // outFile.delete
     }
 }

--- a/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
+++ b/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
@@ -43,9 +43,9 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
 
   trace("nuxmv command line")(nuxmvCmd.mkString(" "))
 
-  val outFile = new File("parikh.smv")
-  // val outFile =
-  //   File.createTempFile("parikh-", ".smv")
+  // val outFile = new File("parikh.smv")
+  val outFile =
+    File.createTempFile("parikh-", ".smv")
 
   val blockNum =
     automataProducts.size
@@ -309,6 +309,6 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
         result
       }
     } finally {
-      // outFile.delete
+      outFile.delete
     }
 }

--- a/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
+++ b/src/main/scala/uuverifiers/catra/NUXMVBackend.scala
@@ -223,6 +223,8 @@ class NUXMVInstance(arguments: CommandLineOptions, instance: Instance)
       }
       out.close()
 
+      printNUXMVModule()
+
       val process = Runtime.getRuntime.exec(nuxmvCmd)
       val stdin = process.getOutputStream
       val stderr = process.getErrorStream


### PR DESCRIPTION
You seem to forget to use the `isPositive` flag when transferring `Inequality` to princess formula. The following instance is `sat`, but Catra answers `unsat`:
```sh
counter int R3, Int1, R1, R2, all_2_0;
synchronised {
automaton aut_X0 {
	init s3;
	s0 -> s1 [97, 97] {R2 += 1};
	s1 -> s1 [97, 97] {R2 += 1};
	s2 -> s2 [48, 48] {R1 += 1, R2 += 1};
	s3 -> s2 [48, 48] {R1 += 1, R2 += 1};
	s3 -> s4 [97, 97] {R2 += 1};
	s4 -> s0 [97, 97] {R2 += 1};
	accepting s0, s1, s2;
};
automaton aut_X1 {
	init s0;
	s0 -> s0 [0, 65535] {R3 += 1};
	accepting s0;
};
};
constraint (R3 + -1*all_2_0 = 0 && all_2_0 + -21 >= 0 && ! (-1*R2 >= 0 && ! (-1*R1 + 1 >= 0 && R1 + -1 >= 0)));

```

My pull request fixes this bug